### PR TITLE
Add link to Arch Linux wiki page

### DIFF
--- a/en-US/installation/install_from_packages.md
+++ b/en-US/installation/install_from_packages.md
@@ -13,6 +13,8 @@ sort: 3
 	- Branch `dev`: [link](https://aur.archlinux.org/packages/gogs-git-dev/)
 	- Release `v0.3.1`: [link](https://aur.archlinux.org/packages/gogs/)
 
+Information for the installation and configuration on Arch Linux can be found at this [Arch Linux Wiki entry](https://wiki.archlinux.org/index.php/Gogs).
+
 ### Ubuntu
 
 ### Mac OS X


### PR DESCRIPTION
Add link to Arch Linux wiki page for detail information about the installation and configuration for Gogs on Arch Linux.
Missing Chinese translation. :smile: 
