### PR TITLE
hacking on gogs: info on how to be able to try your changes locally befo...

### DIFF
--- a/en-US/advanced/hacking_on_gogs.md
+++ b/en-US/advanced/hacking_on_gogs.md
@@ -1,0 +1,31 @@
+---
+name: Hacking on Gogs
+sort: 3
+---
+
+# Hacking on Gogs
+
+If you want to contribute to Gogs you should fork the project and work on the dev branch.
+There is a catch though; some internal packages are referenced by their Github url. So
+you have to trick the Go tool to think that you work on a clone of the official repository.
+
+Start by downloading the source code as you normally would:
+
+    $ go get github.com/gogits/gogs
+
+Now fork the project on Github and then go to gogs' source parent directory:
+
+    $ cd $GOPATH/src/github.com/gogits
+
+Remove the gogs repository and clone your fork in its place:
+
+    $ rm -rf gogs
+    $ git clone git@github.com:<USERNAME>/gogs.git gogs
+
+Go inside the gogs directory, checkout the dev branch and use `go get` again to fetch any new dependencies:
+
+    $ cd gogs
+    $ git checkout dev
+    $ go get
+
+That's it! You are ready to hack on Gogs. Test your changes, push them to your repository and open a pull request.


### PR DESCRIPTION
...re commiting them

Hello, today I tried to submit a patch to Gogs through a pull request and had some trouble compiling my forked repository.

The problem is that inside gogs' code you reference some sub-packages by their github url.
For example inside `cmd/web.go` the imports are:

```
        "github.com/gogits/gogs/routers"
        "github.com/gogits/gogs/routers/admin"
        "github.com/gogits/gogs/routers/api/v1"
        "github.com/gogits/gogs/routers/dev"
        "github.com/gogits/gogs/routers/org"
        "github.com/gogits/gogs/routers/repo"
        "github.com/gogits/gogs/routers/user"
```

I forked and cloned the repository to work on the file `routers/user/settings.go`. But when I did `go build`, go instead of using my `routers/user/settings.go` it used the package from https://github.com/gogits/gogs/routers/user.
So instead of compiling my code, I ended up compiling your code without knowing. It was a bit frustrating because I depend on the compiler output to validate my edits.

In this new page I describe how to trick the go tool to use the user's forked repository instead of yours.
I don't know if there is a better way to handle this. I just though this information may help someone.
