### PR TITLE
Fixed typo in the "[service]" section of the cheat sheet.

### DIFF
--- a/en-US/advanced/configuration_cheat_sheet.md
+++ b/en-US/advanced/configuration_cheat_sheet.md
@@ -57,7 +57,7 @@ If you see anything like `%(X)s`, it's the feature powered by [goconfig](https:/
 - `ACTIVE_CODE_LIVE_MINUTES`: The minutes of active code life time.
 - `RESET_PASSWD_CODE_LIVE_MINUTES`: The minutes of reset password code life time.
 - `REGISTER_EMAIL_CONFIRM`: Enable this to ask for mail confirmation of registration, requires enable `Mailer`.
-- `DISENABLE_REGISTERATION`: Disable registration, which only admin can create accounts for users.
+- `DISABLE_REGISTRATION`: Disable registration, which only admin can create accounts for users.
 - `REQUIRE_SIGNIN_VIEW`: Enable this to force users to log in to view any page.
 - `ENABLE_CACHE_AVATAR`: Enable this to cache avatar from Gravatar.
 - `ENABLE_NOTIFY_MAIL`: This indicates whether send e-mail to watchers of repository when something happens like create issue, requires enable `Mailer`.

--- a/zh-CN/advanced/configuration_cheat_sheet.md
+++ b/zh-CN/advanced/configuration_cheat_sheet.md
@@ -57,7 +57,7 @@ sort: 1
 - `ACTIVE_CODE_LIVE_MINUTES`：激活码的有效期，单位为分钟
 - `RESET_PASSWD_CODE_LIVE_MINUTES`：重置密码的有效期，单位为分钟
 - `REGISTER_EMAIL_CONFIRM`：激活该选项来要求注册用户必须验证邮箱，要求已启用 `Mailer`
-- `DISENABLE_REGISTERATION`：激活该选项来禁止用户注册功能，只能由管理员创建帐号
+- `DISABLE_REGISTRATION`：激活该选项来禁止用户注册功能，只能由管理员创建帐号
 - `REQUIRE_SIGNIN_VIEW`：激活该选项来要求用户必须登录才能浏览任何页面
 - `ENABLE_CACHE_AVATAR`：激活该选项来缓存 Gravatar 的头像
 - `ENABLE_NOTIFY_MAIL`：激活该选项来发送通知邮件给关注者，例如创建 issue 时，要求已启用 `Mailer`


### PR DESCRIPTION
`DISENABLE_REGISTERATION` to `DISABLE_REGISTRATION`
