### PR TITLE
Update migrate page API parameters documentation

### DIFF
--- a/en-US/features/migrate.md
+++ b/en-US/features/migrate.md
@@ -27,7 +27,7 @@ In case you have many repositories need to migrate from same of different source
 |---------|--------|----|
 |`username`|**True**|Operator username|
 |`password`|**True**|Operator password|
-|`clone_addr`|**True**|Clone address (HTTP/HTTPS URL or local path)|
+|`url`|**True**|Clone address (HTTP/HTTPS URL or local path)|
 |`auth_username`|False|Authorization username|
 |`auth_password`|False|Authorization password|
 |`uid`|**True**|Repository owner ID|

--- a/zh-CN/features/migrate.md
+++ b/zh-CN/features/migrate.md
@@ -27,7 +27,7 @@ Gogs 支持从外部 Git 托管源导入功能来帮助您通过 HTTP/HTTPS 协�
 |---------|--------|----|
 |`username`|**是**|操作者用户名|
 |`password`|**是**|操作者密码|
-|`clone_addr`|**是**|克隆地址（HTTP/HTTPS URL 或本地路径）|
+|`url`|**是**|克隆地址（HTTP/HTTPS URL 或本地路径）|
 |`auth_username`|否|授权认证用户名|
 |`auth_password`|否|授权认证密码|
 |`uid`|**是**|仓库拥有者 ID|


### PR DESCRIPTION
Looks like the `clone_addr` parameter is now named `url`.