### PR TITLE
get only last revision when cloning source

### DIFF
--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -82,7 +82,7 @@ In case you want to try `develop` branch:
 ```
 $ mkdir -p $GOPATH/src/github.com/gogits
 $ cd $GOPATH/src/github.com/gogits
-$ git clone -b develop https://github.com/gogits/gogs.git
+$ git clone --depth=1 -b develop https://github.com/gogits/gogs.git
 $ cd gogs
 $ go get ./...
 $ go build

--- a/fr-FR/installation/install_from_source.md
+++ b/fr-FR/installation/install_from_source.md
@@ -82,7 +82,7 @@ Dans le cas où vous voulez essayer la branche `develop` :
 ```
 $ mkdir -p $GOPATH/src/github.com/gogits
 $ cd $GOPATH/src/github.com/gogits
-$ git clone -b develop https://github.com/gogits/gogs.git
+$ git clone --depth=1 -b develop https://github.com/gogits/gogs.git
 $ cd gogs
 $ go get ./...
 $ go build

--- a/zh-CN/installation/install_from_source.md
+++ b/zh-CN/installation/install_from_source.md
@@ -78,7 +78,7 @@ $ gopm bin -u -v gogs -d path/to/anywhere
 ```
 $ mkdir -p $GOPATH/src/github.com/gogits
 $ cd $GOPATH/src/github.com/gogits
-$ git clone -b develop https://github.com/gogits/gogs.git
+$ git clone --depth=1 -b develop https://github.com/gogits/gogs.git
 $ cd gogs
 $ go get ./...
 $ go build


### PR DESCRIPTION
When you clone the code to install from source it is not necessary to download the full history of the branch. The last revision is enough.

This saves disk space, bandwith and time.