### PR TITLE
Fix Links

### DIFF
--- a/en-US/advanced/configuration_for_source_builds.md
+++ b/en-US/advanced/configuration_for_source_builds.md
@@ -185,7 +185,7 @@ You are basically done here, the next step outlines how to make Gogs start when 
 
 ## Adding Gogs to `init.d`
 
-This section describes how to properly start *Gogs* when your linux system reboots. For other platforms, consult the documentation to see how you can do this. For Mac OSX see [this document](/docs/installation/install_gogs_on_mac.md#run-gogs-server) to control app start-ups.
+This section describes how to properly start *Gogs* when your linux system reboots. For other platforms, consult the documentation to see how you can do this. For Mac OSX see [this document](/docs/installation/install_gogs_on_mac#run-gogs-server) to control app start-ups.
 
 If you followed previous steps, you can now enable automatic start of gogs. Under `debian`/`ubuntu`, we will use the script from `$GOPATH/src/github.com/gogits/gogs/scripts/init/debian/gogs`.
 

--- a/en-US/advanced/configuration_for_source_builds.md
+++ b/en-US/advanced/configuration_for_source_builds.md
@@ -237,4 +237,4 @@ Test your setup by running
 
 and visiting the URL for your site (ex. `git.example.com`)
 
-If you want to autostart gogs using `systemd`, check out [the related FAQ](/docs/intro/faqs.md#systemd-service).
+If you want to autostart gogs using `systemd`, check out [the related FAQ](/docs/intro/faqs#systemd-service).

--- a/en-US/advanced/configuration_for_source_builds.md
+++ b/en-US/advanced/configuration_for_source_builds.md
@@ -5,7 +5,7 @@ sort: 4
 
 # Detailed Configuration For Source Builds
 
-Following the instruction of building [from source](/docs/installation/install_from_source.md), you should now have a local user `git` and a working setup of `go` and [Gogs](http://gogs.io/).
+Following the instruction of building [from source](/docs/installation/install_from_source), you should now have a local user `git` and a working setup of `go` and [Gogs](http://gogs.io/).
 We are gong to setup Gogs along with **Nginx**. This way, we can take advantage of Nginx. This is useful for servers that already have an Nginx running.
 
 For the rest fo this document, we'll assume the following:

--- a/en-US/advanced/configuration_for_source_builds.md
+++ b/en-US/advanced/configuration_for_source_builds.md
@@ -15,7 +15,7 @@ For the rest fo this document, we'll assume the following:
 - `postgresql` is your database server
 - and you want your git repository URLs look like `git.example.com`
 
-As mentioned in [Configuration and run](/docs/installation/configuration_and_run.md), you should create your own configuration file in `$GOPATH/src/github.com/gogits/gogs/custom/conf/app.ini`
+As mentioned in [Configuration and run](/docs/installation/configuration_and_run), you should create your own configuration file in `$GOPATH/src/github.com/gogits/gogs/custom/conf/app.ini`
 
 Let's first setup some directories:
 

--- a/en-US/installation/README.md
+++ b/en-US/installation/README.md
@@ -44,4 +44,4 @@ $ sudo apt-get install git
 ## Install Gogs
 
 - [Install from binary](/docs/installation/install_from_binary)
-- [Install from source](http://gogs.io/docs/installation/install_from_source.html)
+- [Install from source](/docs/installation/install_from_source)

--- a/en-US/installation/README.md
+++ b/en-US/installation/README.md
@@ -43,5 +43,5 @@ $ sudo apt-get install git
 
 ## Install Gogs
 
-- [Install from binary](http://gogs.io/docs/installation/install_from_binary.html)
+- [Install from binary](/docs/installation/install_from_binary)
 - [Install from source](http://gogs.io/docs/installation/install_from_source.html)

--- a/en-US/installation/install_from_binary.md
+++ b/en-US/installation/install_from_binary.md
@@ -13,4 +13,4 @@ Please visit to [GitHub Wiki](https://github.com/gogits/gogs/wiki/Download) for 
 2. Remove old `templates` directory.
 3. Unzip archive and copy-paste everything to corresponding(old) location.
 
-See [Configuration and run](configuration_and_run.md) to go further.
+See [Configuration and run](/docs/installation/configuration_and_run) to go further.

--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -113,5 +113,5 @@ $ go build -tags "sqlite redis memcache"
 
 ## Next steps
 
-- See [Configuration and run](configuration_and_run.md) to go further.
+- See [Configuration and run](/docs/installation/configuration_and_run) to go further.
 - For more detailed instructions including setting webserver and database see [the detailed steps](/docs/advanced/configuration_for_source_builds.md).

--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -114,4 +114,4 @@ $ go build -tags "sqlite redis memcache"
 ## Next steps
 
 - See [Configuration and run](/docs/installation/configuration_and_run) to go further.
-- For more detailed instructions including setting webserver and database see [the detailed steps](/docs/advanced/configuration_for_source_builds.md).
+- For more detailed instructions including setting webserver and database see [the detailed steps](/docs/advanced/configuration_for_source_builds).


### PR DESCRIPTION
In the last too links I'm including the anchors `#run-gogs-server` and `#systemd-service` though your markup generated pages doesn't include those anchors to titles as for now. I suppose you will correct that in the future.