### PR TITLE
Include documentation to upgrade Gogs from source

### DIFF
--- a/TOC.ini
+++ b/TOC.ini
@@ -21,7 +21,7 @@
 
 [upgrade]
 -: README
--: install_from_binary
+-: upgrade_from_binary
 
 [features]
 -: README

--- a/TOC.ini
+++ b/TOC.ini
@@ -19,6 +19,10 @@
 -: install_gogs_on_windows
 -: configuration_and_run
 
+[upgrade]
+-: README
+-: install_from_binary
+
 [features]
 -: README
 -: webhook

--- a/en-US/upgrade/README.md
+++ b/en-US/upgrade/README.md
@@ -1,0 +1,5 @@
+---
+root: true
+name: Features
+sort: 2
+---

--- a/en-US/upgrade/README.md
+++ b/en-US/upgrade/README.md
@@ -1,5 +1,3 @@
 ---
-root: true
-name: Features
-sort: 2
+name: Upgrade
 ---

--- a/en-US/upgrade/upgrade_from_source.md
+++ b/en-US/upgrade/upgrade_from_source.md
@@ -1,0 +1,68 @@
+---
+name: From source
+sort: 1
+---
+
+# Upgrade from source
+
+### Check and Set Up the Environment
+
+Check if path is defined in your system
+
+```bash
+sudo su - git
+echo GOROOT
+echo GOPATH
+echo PATH
+```
+
+If isn't defined, set the paths that correspond to your system:
+
+```bash
+cd ~
+echo 'export GOROOT=$HOME/local/go' >> $HOME/.bashrc
+echo 'export GOPATH=$HOME/go' >> $HOME/.bashrc
+echo 'export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bashrc
+source $HOME/.bashrc
+```
+
+## Upgrade Gogs
+
+The general way to upgrade Gogs:
+
+```bash
+# Upgrade source and install dependencies
+$ go get -u github.com/gogits/gogs
+
+# Remove or move old build and build new main program
+$ cd $GOPATH/src/github.com/gogits/gogs
+$ rm gogs # mv gogs gogs.old
+$ go build
+```
+
+### Test Installation
+
+To make sure Gogs is working:
+
+```bash
+cd $GOPATH/src/github.com/gogits/gogs
+./gogs web
+```
+
+If you do not see error messages, hit `Ctrl-C` to stop Gogs.
+
+### Build with SQLite3/Redis/Memcache
+
+If you need to enable SQLite3/Redis/Memcache, please delete directory `$GOPATH/pkg/{GOOS_GOARCH}/github.com/gogits/gogs` and do:
+
+```bash
+# Upgrade source and install dependencies
+$ go get -u -tags "sqlite redis memcache" github.com/gogits/gogs
+
+# Remove or move old build and build new main program
+$ cd $GOPATH/src/github.com/gogits/gogs
+$ rm gogs # mv gogs gogs.old
+$ go build -tags "sqlite redis memcache"
+```
+
+Then, run Gogs again and access from your browser.


### PR DESCRIPTION
This is a simple way to upgrade Gogs from source if you already have Gogs running.