### PR TITLE
Updated to minimize confusion

### DIFF
--- a/en-US/advanced/configuration_cheat_sheet.md
+++ b/en-US/advanced/configuration_cheat_sheet.md
@@ -109,7 +109,7 @@ Any configuration option that is marked by :exclamation: means remain default un
 - `DISABLE_HELO`: Disable HELO operation.
 - `HELO_HOSTNAME`: Custom hostname for HELO operation.
 - `HOST`: SMTP mail host address and port (example: smtp.gogs.io:587).
-- `FROM`: Mail from address, RFC 5322. This can be just an email address, or the "Name" <email@example.com> format.
+- `FROM`: Mail from address, RFC 5322. This can be just an email address, or the "Name" \<email@example.com\> format.
 - `USER`: User name of mailer (usually just your e-mail address).
 - `PASSWD`: Password of mailer.
 - `SKIP_VERIFY`: Do not verify the self-signed certificates.


### PR DESCRIPTION
Previous formatting did not show the `<>`, therefore causing a misconfiguration on my side (until I read RFC 5322).
Hope this helps anyone else, too!

A related link:
http://stackoverflow.com/questions/22433687/how-to-format-an-email-that-hotmail-outlook-is-happy-with