### PR TITLE
Updating "Hacking on Gogs"

### DIFF
--- a/en-US/advanced/hacking_on_gogs.md
+++ b/en-US/advanced/hacking_on_gogs.md
@@ -21,10 +21,10 @@ Remove the gogs repository and clone your fork in its place:
     $ rm -rf gogs
     $ git clone git@github.com:<USERNAME>/gogs.git gogs
 
-Go inside the gogs directory, checkout the dev branch and use `go get` again to fetch any new dependencies:
+Go inside the gogs directory, checkout the dev branch and use `go get -u ./...` again to fetch any new dependencies:
 
     $ cd gogs
     $ git checkout develop
-    $ go get
+    $ go get -u ./...
 
 That's it! You are ready to hack on Gogs. Test your changes, push them to your repository and open a pull request.

--- a/en-US/advanced/hacking_on_gogs.md
+++ b/en-US/advanced/hacking_on_gogs.md
@@ -27,4 +27,11 @@ Go inside the gogs directory, checkout the dev branch and use `go get -u ./...` 
     $ git checkout develop
     $ go get -u ./...
 
+Gogs have a test suite that can be run with the `make test` command. Writing
+test cases is not mandatory to contribute, but we will be happy if you do.
+More information about writing tests in Go can be found on
+[the oficial documentation](golangtesting).
+
 That's it! You are ready to hack on Gogs. Test your changes, push them to your repository and open a pull request.
+
+[golangtesting]: https://golang.org/pkg/testing/


### PR DESCRIPTION
Also, Gogs have 3 different pages with information about how to contribute:

- https://github.com/gogits/gogs/blob/master/CONTRIBUTING.md
- https://github.com/gogits/gogs/wiki/Contributing-Code
- https://gogs.io/docs/advanced/hacking_on_gogs

And they aren't in sync! (Not all information is available on all pages). I think it would be better to consolidate these pages in a single one (making sure it is easily findable).

Just a suggestion.