### PR TITLE
Include unoficial install and deploy on cloud into documentation

### DIFF
--- a/TOC.ini
+++ b/TOC.ini
@@ -17,6 +17,8 @@
 -: install_from_packages
 -: run_as_windows_service
 -: configuration_and_run
+-: unoficial_install
+-: deploy_cloud
 
 [upgrade]
 -: README

--- a/en-US/installation/deploy_cloud.md
+++ b/en-US/installation/deploy_cloud.md
@@ -1,0 +1,15 @@
+---
+name: Deploy to Cloud
+---
+
+# Deploy to Cloud
+
+Other option to run Gogs is using open source or commercial PaaS to deploy Gogs, below have options to this
+
+- [OpenShift](https://github.com/tkisme/gogs-openshift).
+- [Cloudron](https://cloudron.io/appstore.html#io.gogs.cloudronapp).
+- [Scaleway](https://www.scaleway.com/imagehub/gogs/).
+- [Portal](https://portaldemo.xyz/cloud/).
+- [Sandstorm](https://github.com/cem/gogs-sandstorm).
+- [sloppy.io](https://github.com/sloppyio/quickstarters/tree/master/gogs).
+- [YunoHost](https://github.com/mbugeia/gogs_ynh).

--- a/en-US/installation/deploy_cloud.md
+++ b/en-US/installation/deploy_cloud.md
@@ -4,7 +4,7 @@ name: Deploy to Cloud
 
 # Deploy to Cloud
 
-Other option to run Gogs is using open source or commercial PaaS to deploy Gogs, below have options to this
+Other option to run Gogs is with open source or commercial PaaS to deploy Gogs, below have options to this
 
 - [OpenShift](https://github.com/tkisme/gogs-openshift).
 - [Cloudron](https://cloudron.io/appstore.html#io.gogs.cloudronapp).

--- a/en-US/installation/unoficial_install.md
+++ b/en-US/installation/unoficial_install.md
@@ -1,0 +1,17 @@
+---
+name: Unoficial install
+---
+
+# Unoficial installation tutorials
+
+Here is possible to see other unoficial options and tutorials to install Gogs
+
+[How To Set Up Gogs on Ubuntu 14.04 (English)](https://www.digitalocean.com/community/tutorials/how-to-set-up-gogs-on-ubuntu-14-04).
+[Run your own GitHub-like service with the help of Docker (English)](http://blog.hypriot.com/post/run-your-own-github-like-service-with-docker/).
+[使用 Gogs 搭建自己的 Git 服务器 (Chinese)](https://mynook.info/blog/post/host-your-own-git-server-using-gogs).
+[阿里云上 Ubuntu 14.04 64 位安装 Gogs (Chinese)](http://my.oschina.net/luyao/blog/375654).
+[Installing Gogs on FreeBSD (English)](https://www.codejam.info/2015/03/installing-gogs-on-freebsd.html).
+[Gogs on Raspberry Pi (English)](http://blog.meinside.pe.kr/Gogs-on-Raspberry-Pi/).
+[Cloudflare Full SSL with GOGS (Go Git Service) using NGINX (English)](http://www.listekconsulting.com/articles/cloudflare-full-ssl-with-gogs-go-git-service-using-nginx/).
+[Instalando Gogs no Ubuntu (Brazilian Portuguese)](https://www.youtube.com/watch?v=4UkHAR1F7ZA).
+[Install Gogs from binary on VestaCP panel (English)](https://gist.github.com/joubertredrat/74f198300a455e5dcaa9c3660c9d760a).

--- a/en-US/installation/unoficial_install.md
+++ b/en-US/installation/unoficial_install.md
@@ -6,12 +6,12 @@ name: Unoficial install
 
 Here is possible to see other unoficial options and tutorials to install Gogs
 
-[How To Set Up Gogs on Ubuntu 14.04 (English)](https://www.digitalocean.com/community/tutorials/how-to-set-up-gogs-on-ubuntu-14-04).
-[Run your own GitHub-like service with the help of Docker (English)](http://blog.hypriot.com/post/run-your-own-github-like-service-with-docker/).
-[使用 Gogs 搭建自己的 Git 服务器 (Chinese)](https://mynook.info/blog/post/host-your-own-git-server-using-gogs).
-[阿里云上 Ubuntu 14.04 64 位安装 Gogs (Chinese)](http://my.oschina.net/luyao/blog/375654).
-[Installing Gogs on FreeBSD (English)](https://www.codejam.info/2015/03/installing-gogs-on-freebsd.html).
-[Gogs on Raspberry Pi (English)](http://blog.meinside.pe.kr/Gogs-on-Raspberry-Pi/).
-[Cloudflare Full SSL with GOGS (Go Git Service) using NGINX (English)](http://www.listekconsulting.com/articles/cloudflare-full-ssl-with-gogs-go-git-service-using-nginx/).
-[Instalando Gogs no Ubuntu (Brazilian Portuguese)](https://www.youtube.com/watch?v=4UkHAR1F7ZA).
-[Install Gogs from binary on VestaCP panel (English)](https://gist.github.com/joubertredrat/74f198300a455e5dcaa9c3660c9d760a).
+- [How To Set Up Gogs on Ubuntu 14.04 (English)](https://www.digitalocean.com/community/tutorials/how-to-set-up-gogs-on-ubuntu-14-04).
+- [Run your own GitHub-like service with the help of Docker (English)](http://blog.hypriot.com/post/run-your-own-github-like-service-with-docker/).
+- [使用 Gogs 搭建自己的 Git 服务器 (Chinese)](https://mynook.info/blog/post/host-your-own-git-server-using-gogs).
+- [阿里云上 Ubuntu 14.04 64 位安装 Gogs (Chinese)](http://my.oschina.net/luyao/blog/375654).
+- [Installing Gogs on FreeBSD (English)](https://www.codejam.info/2015/03/installing-gogs-on-freebsd.html).
+- [Gogs on Raspberry Pi (English)](http://blog.meinside.pe.kr/Gogs-on-Raspberry-Pi/).
+- [Cloudflare Full SSL with GOGS (Go Git Service) using NGINX (English)](http://www.listekconsulting.com/articles/cloudflare-full-ssl-with-gogs-go-git-service-using-nginx/).
+- [Instalando Gogs no Ubuntu (Brazilian Portuguese)](https://www.youtube.com/watch?v=4UkHAR1F7ZA).
+- [Install Gogs from binary on VestaCP panel (English)](https://gist.github.com/joubertredrat/74f198300a455e5dcaa9c3660c9d760a).


### PR DESCRIPTION
Hi @Unknwon 

I think that is good idea to input more options to install or deploy on documentation to users see that besides the official installation, there are other ways that we users create, like mine that can install on the [VestaCP](https://vestacp.com/) panel as example