### PR TITLE
Update the git remote instead of re-cloning the gogs repo

### DIFF
--- a/en-US/advanced/hacking_on_gogs.md
+++ b/en-US/advanced/hacking_on_gogs.md
@@ -12,18 +12,17 @@ Start by downloading the source code as you normally would:
 
     $ go get github.com/gogits/gogs
 
-Now fork the project on Github and then go to gogs' source parent directory:
+Now fork the project on Github and then go to gogs' source directory:
 
-    $ cd $GOPATH/src/github.com/gogits
+    $ cd $GOPATH/src/github.com/gogits/gogs
 
-Remove the gogs repository and clone your fork in its place:
+Configure the gogs repository to be a clone of your fork:
 
-    $ rm -rf gogs
-    $ git clone git@github.com:<USERNAME>/gogs.git gogs
+    $ git remote set-url origin git@github.com:<USERNAME>/gogs.git
+    $ git fetch
 
-Go inside the gogs directory, checkout the develop branch and use `go get -u ./...` again to fetch any new dependencies:
+Checkout the develop branch and use `go get -u ./...` again to fetch any new dependencies:
 
-    $ cd gogs
     $ git checkout develop
     $ go get -u ./...
 


### PR DESCRIPTION
The 'go get' command already makes a clone of the gogs repository which can then be configure to point at the user's fork without having to re-download the entire repository again.