### PR TITLE
fix apache proxy config

### DIFF
--- a/de-DE/intro/faqs.md
+++ b/de-DE/intro/faqs.md
@@ -67,8 +67,8 @@ Benutze die folgende Konfigurations-Vorlage:
                  Allow from all
         </Proxy>
 
-        ProxyPass /git http://127.0.0.1:6000
-        ProxyPassReverse /git http://127.0.0.1:6000
+        ProxyPass /git http://127.0.0.1:3000/
+        ProxyPassReverse /git http://127.0.0.1:3000/
 </VirtualHost>
 ```
 

--- a/fr-FR/intro/faqs.md
+++ b/fr-FR/intro/faqs.md
@@ -59,8 +59,8 @@ Essayez de suivre le template de configuration :
                  Allow from all
         </Proxy>
 
-        ProxyPass /git http://127.0.0.1:6000
-        ProxyPassReverse /git http://127.0.0.1:6000
+        ProxyPass /git http://127.0.0.1:3000/
+        ProxyPassReverse /git http://127.0.0.1:3000/
 </VirtualHost>
 ```
 


### PR DESCRIPTION
* change port from 6000 to 3000 (default)
* add missing trailing slash

This brings the de-DE and fr-FR translations in sync with the en-US and
zh-CN one.