### PR TITLE
Added ENABLE_GIT_HOOKS setting to cheat sheet

### DIFF
--- a/de-DE/advanced/configuration_cheat_sheet.md
+++ b/de-DE/advanced/configuration_cheat_sheet.md
@@ -93,6 +93,7 @@ Jede Konfiguration, die mit :exclamation: markiert ist, solltest du auf dem Stan
 - `ENABLE_REVERSE_PROXY_AUTHENTICATION`: Aktivieren, um Reverse Proxy Authentication zu erlauben. Details: https://github.com/gogits/gogs/issues/165
 - `ENABLE_REVERSE_PROXY_AUTO_REGISTRATION`: Aktivieren, um Auto-Registrierung für Reverse Authentication zu erlauben.
 - `DISABLE_MINIMUM_KEY_SIZE_CHECK`: Überprüfe nicht die minimale Schlüssellänge für den Schlüsseltyp.
+- `ENABLE_GIT_HOOKS`: Aktiviert das Ausführen von git Hook-Befehlen unter `ROOT/[user name]/[repo name].git/hooks`, welche sich von Webhooks unterscheiden
 
 ## Webhook (`webhook`)
 

--- a/en-US/advanced/configuration_cheat_sheet.md
+++ b/en-US/advanced/configuration_cheat_sheet.md
@@ -95,6 +95,7 @@ Any configuration option that is marked by :exclamation: means that you should k
 - `ENABLE_REVERSE_PROXY_AUTO_REGISTRATION`: Enable this to allow auto-registration for reverse authentication.
 - `DISABLE_MINIMUM_KEY_SIZE_CHECK`: Do not check minimum key size with corresponding type.
 - `ENABLE_CAPTCHA`: Enable this to use captcha validation for registration.
+- `ENABLE_GIT_HOOKS`: Enable the execution of git hooks commands located in `ROOT/[user name]/[repo name].git/hooks` which are different from webhooks
 
 ## Webhook (`webhook`)
 

--- a/fr-FR/advanced/configuration_cheat_sheet.md
+++ b/fr-FR/advanced/configuration_cheat_sheet.md
@@ -71,6 +71,7 @@ Tous les paramètres par défaut peuvent être trouvés dans [app.ini](https://g
 - `ENABLE_REVERSE_PROXY_AUTHENTICATION`: Activez cette option pour permettre l'authentification de proxy inverse, plus en détail : https://github.com/gogits/gogs/issues/165
 - `ENABLE_REVERSE_PROXY_AUTO_REGISTRATION`: Activez cette option pour permettre l'auto-inscriptions pour l'authentification inverse.
 - `DISABLE_MINIMUM_KEY_SIZE_CHECK`: Ne pas vérifier la taille de clé minimale avec le type correspondant.
+- `ENABLE_GIT_HOOKS`: Activez cette option pour permettre l'exécution des git hook commandes qui sont situé sous `ROOT/[user name]/[repo name].git/hooks`
 
 ## Webhook
 


### PR DESCRIPTION
As mentioned in [issue 264](https://github.com/gogits/gogs/issues/264) of the gogs main repo, gogs contains a dedicated setting to allow the execution of git hooks which wasn't reflected in the documentation until now.