### PR TITLE
added mention of missing package to fix gobuild error

### DIFF
--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -109,6 +109,9 @@ $ cd $GOPATH/src/github.com/gogits/gogs
 $ go build -tags "sqlite pam cert"
 ```
 
+If you get error : `fatal error: security/pam_appl.h: No such file or directory`
+then install missing package  `sudo apt-get install libpam0g-dev`
+
 ## Next steps
 
 - See [Configuration and run](/docs/installation/configuration_and_run) to go further.

--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -109,8 +109,7 @@ $ cd $GOPATH/src/github.com/gogits/gogs
 $ go build -tags "sqlite pam cert"
 ```
 
-If you get error: `fatal error: security/pam_appl.h: No such file or directory`
-then install missing package. `sudo apt-get install libpam0g-dev`
+If you get error: `fatal error: security/pam_appl.h: No such file or directory`, then install missing package via `sudo apt-get install libpam0g-dev`.
 
 ## Next steps
 

--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -109,8 +109,8 @@ $ cd $GOPATH/src/github.com/gogits/gogs
 $ go build -tags "sqlite pam cert"
 ```
 
-If you get error : `fatal error: security/pam_appl.h: No such file or directory`
-then install missing package  `sudo apt-get install libpam0g-dev`
+If you get error: `fatal error: security/pam_appl.h: No such file or directory`
+then install missing package. `sudo apt-get install libpam0g-dev`
 
 ## Next steps
 


### PR DESCRIPTION
If this happens

go build error : `fatal error: security/pam_appl.h: No such file or directory`

then install missing package

`sudo apt-get install libpam0g-dev` # debian, ubuntu

`sudo yum install gcc pam-devel `  #  On CentOS, Fedora or RHEL