### PR TITLE
Add sections for proxy with Caddy

### DIFF
--- a/en-US/intro/faqs.md
+++ b/en-US/intro/faqs.md
@@ -117,6 +117,29 @@ $HTTP["url"] =~ "^/gogs" {
     )
 }
 ```
+#### How do I use Caddy with Reverse Proxy?
+
+Add following server block to your Caddyfile and reload the configuration:
+
+```
+git.example.com {
+    proxy / http://localhost:3000
+}
+```
+
+##### How do I set up a sub-path with Caddy?
+
+In case you need to use a sub-path for your Gogs instance, you can change your Caddy configuration to the following
+(note to the suffix `/`):
+
+```
+git.example.com {
+
+    proxy /gogs/ http://localhost:3000
+}
+```
+
+
 
 #### How do I set up HTTPS?
 

--- a/en-US/intro/faqs.md
+++ b/en-US/intro/faqs.md
@@ -134,12 +134,9 @@ In case you need to use a sub-path for your Gogs instance, you can change your C
 
 ```
 git.example.com {
-
     proxy /gogs/ http://localhost:3000
 }
 ```
-
-
 
 #### How do I set up HTTPS?
 


### PR DESCRIPTION
I have added sections to configure [Caddy](https://caddyserver.com/) (a webserver written in GO)  as a proxy to point to a Gogs instance.