### PR TITLE
Update to upgrade-from-binary steps

### DIFF
--- a/en-US/upgrade/upgrade_from_binary.md
+++ b/en-US/upgrade/upgrade_from_binary.md
@@ -39,9 +39,7 @@ gogs gogs_old  gogs-repositories $OS_$ARCH.tar.gz
 Copy `custom`, `data` and `log` directories to unzipped directory:
 
 ```bash
-$ cp -R gogs_old/custom gogs
-$ cp -R gogs_old/data gogs
-$ cp -R gogs_old/log gogs
+$ cp -R gogs_old/{custom,data,log} gogs
 ```
 
 Then, run and test in your browser:

--- a/en-US/upgrade/upgrade_from_binary.md
+++ b/en-US/upgrade/upgrade_from_binary.md
@@ -50,3 +50,10 @@ $ ./gogs web
 ```
 
 Well done!
+
+**Note** If you use the bundled `scripts`, make sure they are executable:
+
+```bash
+grep -rl '^#!' scripts | xargs chmod +x
+```
+


### PR DESCRIPTION
During a recent upgrade (https://dl.gogs.io/0.10.18/linux_amd64.tar.gz), my init.d script stopped working because the bundled script didn't have the execute bit set. 

```
$ sudo service gogs start
gogs: unrecognized service
$ ls -l /etc/init.d/gogs
lrwxrwxrwx 1 root root 39 Oct 10 10:07 /etc/init.d/gogs -> /home/git/gogs/scripts/init/debian/gogs
$ ls -l /home/git/gogs/scripts/init/debian/gogs
-rw-r--r-- 1 git git 3112 Feb 21 09:44 /home/git/gogs/scripts/init/debian/gogs
$ sudo chmod +x /home/git/gogs/scripts/init/debian/gogs
$ sudo service gogs start
 * Starting Gogs gogs                                                                                                           [ OK ]
```

I suppose this might be better fixed in the packaging scripts in the main gogs repo, but I didn't feel comfortable editing that. Docs are just docs, right? 😁 

I also condensed the three `cp -R ...` commands into a single command using brace expansion, which is a standard bash thing.