### PR TITLE
document the section name for "Overall" section

### DIFF
--- a/en-US/advanced/configuration_cheat_sheet.md
+++ b/en-US/advanced/configuration_cheat_sheet.md
@@ -10,7 +10,7 @@ Before getting started, make sure you know that any change to the configuration 
 
 All **default settings** can be found in [app.ini](https://github.com/gogits/gogs/blob/master/conf/app.ini). If you see anything which looks like `%(X)s`, it is a feature powered by [ini](https://github.com/go-ini/ini/#recursive-values) for reading values recursively.
 
-### Overall
+### Overall (`DEFAULT`)
 
 Name|Description
 ----|-----------


### PR DESCRIPTION
In certain contexts, the Gogs configuration is put together by concatenating multiple files. In such a situation, it becomes hard to override the values in the Overall section as they get pushed into whatever section is defined last, unless you know that it can be specified via `DEFAULT`.