### PR TITLE
Fix typo in sqlite build tag

### DIFF
--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -96,7 +96,7 @@ A couple of things do not come with Gogs automatically, you need to compile Gogs
 
 Available build tags are:
 
-- `sqlite3`: SQLite3 database support
+- `sqlite`: SQLite3 database support
 - `pam`: PAM authentication support
 - `cert`: Generate self-signed certificates support
 - `miniwinsvc`: Builtin windows service support (or you can use NSSM to create a service)


### PR DESCRIPTION
The docs says `sqlite3` is an available build tags but the correct one is `sqlite`. It's correctly referenced further in the guide but this typo made me rebuild gogs quite a few times before I read the whole page.