### PR TITLE
Add gogs-repositories to the copy command (without gogs wont work)

### DIFF
--- a/en-US/upgrade/upgrade_from_binary.md
+++ b/en-US/upgrade/upgrade_from_binary.md
@@ -39,7 +39,7 @@ gogs gogs_old  gogs-repositories $OS_$ARCH.tar.gz
 Copy `custom`, `data`, and `log` directories to the unzipped directory:
 
 ```bash
-$ cp -R gogs_old/{custom,data,log} gogs
+$ cp -R gogs_old/{custom,data,log,gogs-repositories} gogs
 ```
 
 Then, run and test in your browser:


### PR DESCRIPTION
I followed the instructions for a gogs upgrade but found out that a very important directory was missing- the one that holds all of the actual git repositories!

This amends the documentation to include it